### PR TITLE
Fixed clippy warnings

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -117,7 +117,8 @@ fn CompileIdentifier(scope: usize, names: Option<&Vec<String>>, expr: Expression
 						} else {
 							panic!("This message should never appear");
 						};
-						write!(checked, "[({})]", rexpr).expect("");
+						write!(checked, "[({})]", rexpr)
+							.expect("something really unexpected happened");
 					}
 					"]" => {}
 					_ => checked += lexeme,
@@ -125,11 +126,10 @@ fn CompileIdentifier(scope: usize, names: Option<&Vec<String>>, expr: Expression
 			}
 			EXPR(expr) => {
 				let expr = CompileExpression(scope, names, expr);
-				write!(checked, "({})]", expr).expect("");
+				write!(checked, "({})]", expr).expect("something really unexpected happened");
 			}
-			CALL(args) => {
-				write!(checked, "({})", CompileExpressions(scope, names, args)).expect("")
-			}
+			CALL(args) => write!(checked, "({})", CompileExpressions(scope, names, args))
+				.expect("something really unexpected happened"),
 			_ => {}
 		}
 	}
@@ -282,7 +282,7 @@ pub fn CompileTokens(scope: usize, ctokens: Expression) -> String {
 							"rawset(_G, \"{}\", {});{}{}",
 							name, value, line, end
 						)
-						.expect("");
+						.expect("something really unexpected happened");
 					}
 					result
 				} else {
@@ -404,7 +404,8 @@ pub fn CompileTokens(scope: usize, ctokens: Expression) -> String {
 							Some(_) => "else",
 							_ => "end",
 						};
-						write!(result, "{} {}{}{}", pre, condition, code, end).expect("");
+						write!(result, "{} {}{}{}", pre, condition, code, end)
+							.expect("something really unexpected happened");
 					}
 					result
 				};

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn CompileCode(code: String, name: String, scope: usize) -> Result<String, Strin
 fn CompileFile(path: &Path, name: String, scope: usize) -> Result<String, String> {
 	let mut code: String = String::new();
 	check!(check!(File::open(path)).read_to_string(&mut code));
-	Ok(CompileCode(code, name, scope)?)
+	CompileCode(code, name, scope)
 }
 
 fn CompileFolder(path: &Path, rpath: String) -> Result<(), String> {
@@ -134,7 +134,7 @@ fn CompileFolder(path: &Path, rpath: String) -> Result<(), String> {
 			.to_string_lossy()
 			.into_owned();
 		let filePathName: String = format!("{}/{}", path.display(), name);
-		let filepath: &Path = &Path::new(&filePathName);
+		let filepath: &Path = Path::new(&filePathName);
 		let rname = rpath.clone() + &name;
 		if filepath.is_dir() {
 			CompileFolder(filepath, rname + ".")?;
@@ -172,7 +172,7 @@ fn main() -> Result<(), String> {
 	}
 	let codepath = cli.path.unwrap();
 	if arg!(ENV_PATHISCODE) {
-		let code = CompileCode(codepath.clone(), String::from("(command line)"), 0)?;
+		let code = CompileCode(codepath, String::from("(command line)"), 0)?;
 		println!("{}", code);
 		return Ok(());
 	}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,13 @@
 #![allow(non_camel_case_types)]
 
 use self::ComplexToken::*;
-use crate::{compiler::CompileTokens, finaloutput, ENV_JITBIT, ENV_CONTINUE, ENV_DEBUGCOMMENTS, TokenType, Token};
 use crate::TokenType::*;
-use std::{cmp, collections::LinkedList};
 use crate::TokenType::{COMMA, CURLY_BRACKET_CLOSED, DEFINE, ROUND_BRACKET_CLOSED};
+use crate::{
+	compiler::CompileTokens, finaloutput, Token, TokenType, ENV_CONTINUE, ENV_DEBUGCOMMENTS,
+	ENV_JITBIT,
+};
+use std::{cmp, collections::LinkedList};
 
 macro_rules! expression {
 	($($x: expr),*) => {
@@ -135,8 +138,8 @@ impl ParserInfo {
 		ParserInfo {
 			current: 0,
 			size: tokens.len() - 1,
-			tokens: tokens,
-			filename: filename,
+			tokens,
+			filename,
 			expr: Expression::new(),
 			testing: None,
 			localid: 0,
@@ -333,10 +336,7 @@ impl ParserInfo {
 						}
 						SQUARE_BRACKET_CLOSED => {
 							qscope -= 1;
-							match qscope {
-								0 => false,
-								_ => true,
-							}
+							!matches!(qscope, 0)
 						}
 						EOF => return Err(self.expectedBefore("]", "<end>", self.peek(0).line)),
 						_ => true,
@@ -381,13 +381,7 @@ impl ParserInfo {
 			let start = self.current;
 			let mut cscope = 0u8;
 			while match self.peek(0).kind {
-				COMMA | CURLY_BRACKET_CLOSED => {
-					if cscope == 0 {
-						false
-					} else {
-						true
-					}
-				}
+				COMMA | CURLY_BRACKET_CLOSED => cscope == 0,
 				ROUND_BRACKET_OPEN => {
 					cscope += 1;
 					true
@@ -416,31 +410,31 @@ impl ParserInfo {
 	}
 
 	fn checkOperator(&mut self, t: &Token, checkback: bool) -> Result<(), String> {
-		if match self.peek(0).kind {
-			NUMBER | IDENTIFIER | STRING | DOLLAR | PROTECTED_GET | TRUE | FALSE | MINUS
-			| BIT_NOT | NIL | NOT | HASHTAG | ROUND_BRACKET_OPEN | TREDOTS => false,
-			_ => true,
-		} {
+		if !matches!(
+			self.peek(0).kind,
+			NUMBER
+				| IDENTIFIER | STRING
+				| DOLLAR | PROTECTED_GET
+				| TRUE | FALSE | MINUS
+				| BIT_NOT | NIL | NOT
+				| HASHTAG | ROUND_BRACKET_OPEN
+				| TREDOTS
+		) {
 			return Err(self.error(
 				format!("Operator '{}' has invalid right hand token", t.lexeme),
 				t.line,
 			));
 		}
 		if checkback
-			&& match self.lookBack(1).kind {
-			NUMBER
-			| IDENTIFIER
-			| STRING
-			| DOLLAR
-			| TRUE
-			| FALSE
-			| NIL
-			| ROUND_BRACKET_CLOSED
-			| SQUARE_BRACKET_CLOSED
-			| TREDOTS => false,
-			_ => true,
-		}
-		{
+			&& !matches!(
+				self.lookBack(1).kind,
+				NUMBER
+					| IDENTIFIER | STRING
+					| DOLLAR | TRUE | FALSE
+					| NIL | ROUND_BRACKET_CLOSED
+					| SQUARE_BRACKET_CLOSED
+					| TREDOTS
+			) {
 			return Err(self.error(
 				format!("Operator '{}' has invalid left hand token", t.lexeme),
 				t.line,
@@ -471,10 +465,7 @@ impl ParserInfo {
 
 	fn checkIndex(&mut self, t: &Token, expr: &mut Expression, lexeme: &str) -> Result<(), String> {
 		if !self.compare(IDENTIFIER)
-			|| match self.lookBack(0).kind {
-			IDENTIFIER | SQUARE_BRACKET_CLOSED => true,
-			_ => false,
-		}
+			|| matches!(self.lookBack(0).kind, IDENTIFIER | SQUARE_BRACKET_CLOSED)
 		{
 			return Err(self.error(
 				format!("'{}' should be used only when indexing", t.lexeme),
@@ -554,10 +545,10 @@ impl ParserInfo {
 					expr.push_back(SYMBOL(String::from("~=")))
 				}
 				HASHTAG => {
-					if match self.peek(0).kind {
-						IDENTIFIER | CURLY_BRACKET_OPEN | ROUND_BRACKET_OPEN => false,
-						_ => true,
-					} {
+					if !matches!(
+						self.peek(0).kind,
+						IDENTIFIER | CURLY_BRACKET_OPEN | ROUND_BRACKET_OPEN
+					) {
 						let t = self.peek(0);
 						return Err(self.expected("<table>", &t.lexeme, t.line));
 					}
@@ -588,10 +579,7 @@ impl ParserInfo {
 						let start = i.peek(0).line;
 						let expr = i.buildExpression(None)?;
 						let end = i.lookBack(1).line;
-						if match i.lookBack(0).kind {
-							CURLY_BRACKET_CLOSED | DEFAULT => true,
-							_ => false,
-						} {
+						if matches!(i.lookBack(0).kind, CURLY_BRACKET_CLOSED | DEFAULT) {
 							i.current -= 1
 						}
 						Ok(CodeBlock {
@@ -723,7 +711,7 @@ impl ParserInfo {
 				_ => break t,
 			}
 		};
-		if expr.len() == 0 {
+		if expr.is_empty() {
 			return Err(self.expected("<expr>", &last.lexeme, last.line));
 		}
 		self.assertEnd(&self.lookBack(0), end, expr)
@@ -1217,7 +1205,7 @@ pub fn ParseTokens(tokens: Vec<Token>, filename: String) -> Result<Expression, S
 				} {}
 				i.current -= 1;
 				let checkt = i.lookBack(0);
-				let check = checkt.kind.clone() as u8;
+				let check = checkt.kind as u8;
 				if check < DEFINE as u8 || check > MODULATE as u8 {
 					return Err(i.expected("=", &checkt.lexeme, checkt.line));
 				}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2,7 +2,8 @@
 
 use self::TokenType::*;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[rustfmt::skip]
 pub enum TokenType {
 	//symbols
 	ROUND_BRACKET_OPEN, ROUND_BRACKET_CLOSED, SQUARE_BRACKET_OPEN,
@@ -38,11 +39,7 @@ pub struct Token {
 
 impl Token {
 	pub fn new(kind: TokenType, lexeme: String, line: usize) -> Token {
-		Token {
-			kind: kind,
-			lexeme: String::from(lexeme),
-			line: line,
-		}
+		Token { kind, lexeme, line }
 	}
 }
 
@@ -96,7 +93,7 @@ impl CodeInfo {
 		if self.at(self.current) != expected {
 			return false;
 		}
-		self.current = self.current + 1;
+		self.current += 1;
 		true
 	}
 
@@ -154,7 +151,9 @@ impl CodeInfo {
 	fn warning(&mut self, message: impl Into<String>) {
 		println!(
 			"Error in file \"{}\" at line {}!\nError: \"{}\"\n",
-			self.filename, self.line, message.into()
+			self.filename,
+			self.line,
+			message.into()
 		);
 		self.errored = true;
 	}
@@ -215,17 +214,17 @@ impl CodeInfo {
 		} else {
 			self.current += 1;
 			let mut literal: String = self.substr(self.start + 1, self.current - 1);
-			literal.retain(|c| match c {
-				'\r' | '\n' | '\t' => false,
-				_ => true,
-			});
+			literal.retain(|c| !matches!(c, '\r' | '\n' | '\t'));
 			self.addLiteralToken(STRING, literal);
 		}
 		self.line = aline;
 	}
 
 	fn reserved(&mut self, keyword: &str, msg: &str) -> TokenType {
-		self.warning(format!("'{}' is a reserved keyword in Lua and it cannot be used as a variable, {}", keyword, msg));
+		self.warning(format!(
+			"'{}' is a reserved keyword in Lua and it cannot be used as a variable, {}",
+			keyword, msg
+		));
 		IDENTIFIER
 	}
 }
@@ -273,7 +272,7 @@ pub fn ScanCode(code: String, filename: String) -> Result<Vec<Token>, String> {
 					}
 				}
 				'*' => {
-					while !i.ended() && !(i.peek(0) == '*' && i.peek(1) == '/') {
+					while !(i.ended() || i.peek(0) == '*' && i.peek(1) == '/') {
 						if i.peek(0) == '\n' {
 							i.line += 1
 						}
@@ -338,8 +337,7 @@ pub fn ScanCode(code: String, filename: String) -> Result<Vec<Token>, String> {
 									|c| {
 										let c = *c;
 										c.is_ascii_digit()
-											|| (c >= 'a' && c <= 'f')
-											|| (c >= 'A' && c <= 'F')
+											|| ('a'..='f').contains(&c) || ('A'..='F').contains(&c)
 									},
 									false,
 								);


### PR DESCRIPTION
As per title. Now the code *seems* to run a bit faster (before I got mostly times of about 0.00004 seconds, now 0.00003 seconds, but the reason may lie elsewhere).
Nonetheless, there were code portions such as
```rust
if var == true {
  true
} else {
  false
}
```

Another addition was the `#[rustfmt::skip]` on top of `TokenType`, that line is needed to don't let the formatter "uglify" that `enum`.