### PR TITLE
Removed `unsafe`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ winres = "0.1"
 
 [dependencies]
 clap = {version = "3.1.6", features = ["derive"]}
+lazy_static = "1.4.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,94 @@
+use std::fmt::Write;
+
+pub struct EnvData {
+	env_tokens: bool,
+	env_struct: bool,
+	env_output: bool,
+	env_jitbit: Option<String>,
+	env_continue: bool,
+	env_dontsave: bool,
+	env_pathiscode: bool,
+	env_rawsetglobals: bool,
+	env_debugcomments: bool,
+
+	ouput_code: String,
+}
+
+impl EnvData {
+	pub fn new() -> Self {
+		Self {
+			env_tokens: false,
+			env_struct: false,
+			env_output: false,
+			env_jitbit: None,
+			env_continue: false,
+			env_dontsave: false,
+			env_pathiscode: false,
+			env_rawsetglobals: false,
+			env_debugcomments: false,
+			ouput_code: String::new(),
+		}
+	}
+
+	pub fn set_data(
+		&mut self,
+		env_tokens: bool,
+		env_struct: bool,
+		env_output: bool,
+		env_jitbit: Option<String>,
+		env_continue: bool,
+		env_dontsave: bool,
+		env_pathiscode: bool,
+		env_rawsetglobals: bool,
+		env_debugcomments: bool,
+	) {
+		self.env_tokens = env_tokens;
+		self.env_struct = env_struct;
+		self.env_output = env_output;
+		self.env_jitbit = env_jitbit;
+		self.env_continue = env_continue;
+		self.env_dontsave = env_dontsave;
+		self.env_pathiscode = env_pathiscode;
+		self.env_rawsetglobals = env_rawsetglobals;
+		self.env_debugcomments = env_debugcomments;
+	}
+	pub fn env_tokens(&self) -> bool {
+		self.env_tokens
+	}
+	pub fn env_struct(&self) -> bool {
+		self.env_struct
+	}
+	pub fn env_output(&self) -> bool {
+		self.env_output
+	}
+	pub fn env_jitbit(&self) -> &Option<String> {
+		&self.env_jitbit
+	}
+	pub fn env_continue(&self) -> bool {
+		self.env_continue
+	}
+	pub fn env_dontsave(&self) -> bool {
+		self.env_dontsave
+	}
+	pub fn env_pathiscode(&self) -> bool {
+		self.env_pathiscode
+	}
+	pub fn env_rawsetglobals(&self) -> bool {
+		self.env_rawsetglobals
+	}
+	pub fn env_debugcomments(&self) -> bool {
+		self.env_debugcomments
+	}
+	pub fn ouput_code(&self) -> &str {
+		&self.ouput_code
+	}
+	pub fn add_output_code(&mut self, add: String) {
+		write!(self.ouput_code, "{}", add).expect("something really unexpected happened");
+	}
+}
+
+impl Default for EnvData {
+	fn default() -> Self {
+		Self::new()
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,24 @@
+use std::sync::RwLock;
+
+use lazy_static::lazy_static;
+
+use crate::env::EnvData;
+
+pub mod compiler;
+pub mod env;
+pub mod parser;
+pub mod scanner;
+
+lazy_static! {
+	pub static ref ENV_DATA: RwLock<EnvData> = RwLock::new(EnvData::new());
+}
+
+#[macro_export]
+macro_rules! check {
+	($tocheck: expr) => {
+		match $tocheck {
+			Ok(t) => t,
+			Err(e) => return Err(e.to_string()),
+		}
+	};
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,14 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
-macro_rules! check {
-	($tocheck: expr) => {
-		match $tocheck {
-			Ok(t) => t,
-			Err(e) => return Err(e.to_string()),
-		}
-	};
-}
-
-macro_rules! arg {
-	($name: expr) => {
-		unsafe { $name }
-	};
-}
-
-mod compiler;
-mod parser;
-mod scanner;
-
-use clap::Parser;
-use compiler::*;
-use parser::*;
-use scanner::*;
 use std::{fs, fs::File, io::prelude::*, path::Path, time::Instant};
 
-pub static mut finaloutput: String = String::new();
+use clap::Parser;
 
-pub static mut ENV_TOKENS: bool = false;
-pub static mut ENV_STRUCT: bool = false;
-pub static mut ENV_OUTPUT: bool = false;
-pub static mut ENV_JITBIT: Option<String> = None;
-pub static mut ENV_CONTINUE: bool = false;
-pub static mut ENV_DONTSAVE: bool = false;
-pub static mut ENV_PATHISCODE: bool = false;
-pub static mut ENV_RAWSETGLOBALS: bool = false;
-pub static mut ENV_DEBUGCOMMENTS: bool = false;
+use clue::compiler::*;
+use clue::parser::*;
+use clue::scanner::*;
+use clue::{check, ENV_DATA};
 
 #[derive(Parser)]
 #[clap(about, version, long_about = None)]
@@ -93,21 +65,24 @@ struct Cli {
 }
 
 fn AddToOutput(string: &str) {
-	unsafe { finaloutput += string }
+	ENV_DATA
+		.write()
+		.expect("Can't lock env_data")
+		.add_output_code(String::from(string));
 }
 
 fn CompileCode(code: String, name: String, scope: usize) -> Result<String, String> {
 	let time = Instant::now();
 	let tokens: Vec<Token> = ScanCode(code, name.clone())?;
-	if arg!(ENV_TOKENS) {
+	if ENV_DATA.read().expect("Can't lock env_data").env_tokens() {
 		println!("Scanned tokens of file \"{}\":\n{:#?}", name, tokens);
 	}
 	let ctokens = ParseTokens(tokens, name.clone())?;
-	if arg!(ENV_STRUCT) {
+	if ENV_DATA.read().expect("Can't lock env_data").env_struct() {
 		println!("Parsed structure of file \"{}\":\n{:#?}", name, ctokens);
 	}
 	let code = CompileTokens(scope, ctokens);
-	if arg!(ENV_OUTPUT) {
+	if ENV_DATA.read().expect("Can't lock env_data").env_output() {
 		println!("Compiled Lua code of file \"{}\":\n{}", name, code);
 	}
 	println!(
@@ -156,22 +131,26 @@ fn main() -> Result<(), String> {
 		println!("{}", include_str!("../LICENSE"));
 		return Ok(());
 	}
-	unsafe {
-		ENV_TOKENS = cli.tokens;
-		ENV_STRUCT = cli.r#struct;
-		ENV_OUTPUT = cli.output;
-		ENV_JITBIT = cli.jitbit;
-		ENV_CONTINUE = cli.r#continue;
-		ENV_DONTSAVE = cli.dontsave;
-		ENV_PATHISCODE = cli.pathiscode;
-		ENV_RAWSETGLOBALS = cli.rawsetglobals;
-		ENV_DEBUGCOMMENTS = cli.debugcomments;
-	}
-	if let Some(bit) = arg!(&ENV_JITBIT) {
+	ENV_DATA.write().expect("Can't lock env_data").set_data(
+		cli.tokens,
+		cli.r#struct,
+		cli.output,
+		cli.jitbit,
+		cli.r#continue,
+		cli.dontsave,
+		cli.pathiscode,
+		cli.rawsetglobals,
+		cli.debugcomments,
+	);
+	if let Some(bit) = &ENV_DATA.read().expect("Can't lock env_data").env_jitbit() {
 		AddToOutput(&format!("local {} = require(\"bit\");\n", bit));
 	}
 	let codepath = cli.path.unwrap();
-	if arg!(ENV_PATHISCODE) {
+	if ENV_DATA
+		.read()
+		.expect("Can't lock env_data")
+		.env_pathiscode()
+	{
 		let code = CompileCode(codepath, String::from("(command line)"), 0)?;
 		println!("{}", code);
 		return Ok(());
@@ -181,7 +160,7 @@ fn main() -> Result<(), String> {
 		AddToOutput(include_str!("base.lua"));
 		CompileFolder(path, String::new())?;
 		AddToOutput("\r}\nimport(\"main\")");
-		if !arg!(ENV_DONTSAVE) {
+		if !ENV_DATA.read().expect("Can't lock env_data").env_dontsave() {
 			let outputname = &format!("{}.lua", cli.outputname);
 			let compiledname = if path.display().to_string().ends_with('/')
 				|| path.display().to_string().ends_with('\\')
@@ -190,7 +169,10 @@ fn main() -> Result<(), String> {
 			} else {
 				format!("{}/{}", path.display(), outputname)
 			};
-			check!(fs::write(compiledname, unsafe { &finaloutput }))
+			check!(fs::write(
+				compiledname,
+				ENV_DATA.read().expect("Can't lock env_data").ouput_code()
+			))
 		}
 	} else if path.is_file() {
 		let code = CompileFile(
@@ -199,10 +181,13 @@ fn main() -> Result<(), String> {
 			0,
 		)?;
 		AddToOutput(&code);
-		if !arg!(ENV_DONTSAVE) {
+		if !ENV_DATA.read().expect("Can't lock env_data").env_dontsave() {
 			let compiledname =
 				String::from(path.display().to_string().strip_suffix(".clue").unwrap()) + ".lua";
-			check!(fs::write(compiledname, unsafe { &finaloutput }))
+			check!(fs::write(
+				compiledname,
+				ENV_DATA.read().expect("Can't lock env_data").ouput_code()
+			))
 		}
 	} else {
 		return Err(String::from("The given path doesn't exist"));


### PR DESCRIPTION
This pr resolves #15.
A lot of things needed to change but for the better.
First of all, I needed to add the `lazy_static` dependency, I used it to instantiate and hold all the data.
Then, I implemented a `struct` containing all the data and getters for it, that struct has even a convenient function for adding things to the output code.
I wrapped that struct inside a `RwLock`, if in the future the need arises (the other option was `Mutex`).
I created `lib.rs` that contains `mod`s and `macro`s and removed the `arg` macro as it is useless at this point (there's no more need for `unsafe`)
I added a configuration file for `clippy` because it was angry that `EnvData::set_data` had 10 arguments, 3 more of the max he tolerated.