### PR TITLE
Revert "Fixed clippy warnings"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn CompileCode(code: String, name: String, scope: usize) -> Result<String, Strin
 fn CompileFile(path: &Path, name: String, scope: usize) -> Result<String, String> {
 	let mut code: String = String::new();
 	check!(check!(File::open(path)).read_to_string(&mut code));
-	CompileCode(code, name, scope)
+	Ok(CompileCode(code, name, scope)?)
 }
 
 fn CompileFolder(path: &Path, rpath: String) -> Result<(), String> {
@@ -134,7 +134,7 @@ fn CompileFolder(path: &Path, rpath: String) -> Result<(), String> {
 			.to_string_lossy()
 			.into_owned();
 		let filePathName: String = format!("{}/{}", path.display(), name);
-		let filepath: &Path = Path::new(&filePathName);
+		let filepath: &Path = &Path::new(&filePathName);
 		let rname = rpath.clone() + &name;
 		if filepath.is_dir() {
 			CompileFolder(filepath, rname + ".")?;
@@ -172,7 +172,7 @@ fn main() -> Result<(), String> {
 	}
 	let codepath = cli.path.unwrap();
 	if arg!(ENV_PATHISCODE) {
-		let code = CompileCode(codepath, String::from("(command line)"), 0)?;
+		let code = CompileCode(codepath.clone(), String::from("(command line)"), 0)?;
 		println!("{}", code);
 		return Ok(());
 	}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,10 @@
 #![allow(non_camel_case_types)]
 
 use self::ComplexToken::*;
+use crate::{compiler::CompileTokens, finaloutput, ENV_JITBIT, ENV_CONTINUE, ENV_DEBUGCOMMENTS, TokenType, Token};
 use crate::TokenType::*;
-use crate::TokenType::{COMMA, CURLY_BRACKET_CLOSED, DEFINE, ROUND_BRACKET_CLOSED};
-use crate::{
-	compiler::CompileTokens, finaloutput, Token, TokenType, ENV_CONTINUE, ENV_DEBUGCOMMENTS,
-	ENV_JITBIT,
-};
 use std::{cmp, collections::LinkedList};
+use crate::TokenType::{COMMA, CURLY_BRACKET_CLOSED, DEFINE, ROUND_BRACKET_CLOSED};
 
 macro_rules! expression {
 	($($x: expr),*) => {
@@ -138,8 +135,8 @@ impl ParserInfo {
 		ParserInfo {
 			current: 0,
 			size: tokens.len() - 1,
-			tokens,
-			filename,
+			tokens: tokens,
+			filename: filename,
 			expr: Expression::new(),
 			testing: None,
 			localid: 0,
@@ -336,7 +333,10 @@ impl ParserInfo {
 						}
 						SQUARE_BRACKET_CLOSED => {
 							qscope -= 1;
-							!matches!(qscope, 0)
+							match qscope {
+								0 => false,
+								_ => true,
+							}
 						}
 						EOF => return Err(self.expectedBefore("]", "<end>", self.peek(0).line)),
 						_ => true,
@@ -381,7 +381,13 @@ impl ParserInfo {
 			let start = self.current;
 			let mut cscope = 0u8;
 			while match self.peek(0).kind {
-				COMMA | CURLY_BRACKET_CLOSED => cscope == 0,
+				COMMA | CURLY_BRACKET_CLOSED => {
+					if cscope == 0 {
+						false
+					} else {
+						true
+					}
+				}
 				ROUND_BRACKET_OPEN => {
 					cscope += 1;
 					true
@@ -410,31 +416,31 @@ impl ParserInfo {
 	}
 
 	fn checkOperator(&mut self, t: &Token, checkback: bool) -> Result<(), String> {
-		if !matches!(
-			self.peek(0).kind,
-			NUMBER
-				| IDENTIFIER | STRING
-				| DOLLAR | PROTECTED_GET
-				| TRUE | FALSE | MINUS
-				| BIT_NOT | NIL | NOT
-				| HASHTAG | ROUND_BRACKET_OPEN
-				| TREDOTS
-		) {
+		if match self.peek(0).kind {
+			NUMBER | IDENTIFIER | STRING | DOLLAR | PROTECTED_GET | TRUE | FALSE | MINUS
+			| BIT_NOT | NIL | NOT | HASHTAG | ROUND_BRACKET_OPEN | TREDOTS => false,
+			_ => true,
+		} {
 			return Err(self.error(
 				format!("Operator '{}' has invalid right hand token", t.lexeme),
 				t.line,
 			));
 		}
 		if checkback
-			&& !matches!(
-				self.lookBack(1).kind,
-				NUMBER
-					| IDENTIFIER | STRING
-					| DOLLAR | TRUE | FALSE
-					| NIL | ROUND_BRACKET_CLOSED
-					| SQUARE_BRACKET_CLOSED
-					| TREDOTS
-			) {
+			&& match self.lookBack(1).kind {
+			NUMBER
+			| IDENTIFIER
+			| STRING
+			| DOLLAR
+			| TRUE
+			| FALSE
+			| NIL
+			| ROUND_BRACKET_CLOSED
+			| SQUARE_BRACKET_CLOSED
+			| TREDOTS => false,
+			_ => true,
+		}
+		{
 			return Err(self.error(
 				format!("Operator '{}' has invalid left hand token", t.lexeme),
 				t.line,
@@ -465,7 +471,10 @@ impl ParserInfo {
 
 	fn checkIndex(&mut self, t: &Token, expr: &mut Expression, lexeme: &str) -> Result<(), String> {
 		if !self.compare(IDENTIFIER)
-			|| matches!(self.lookBack(0).kind, IDENTIFIER | SQUARE_BRACKET_CLOSED)
+			|| match self.lookBack(0).kind {
+			IDENTIFIER | SQUARE_BRACKET_CLOSED => true,
+			_ => false,
+		}
 		{
 			return Err(self.error(
 				format!("'{}' should be used only when indexing", t.lexeme),
@@ -545,10 +554,10 @@ impl ParserInfo {
 					expr.push_back(SYMBOL(String::from("~=")))
 				}
 				HASHTAG => {
-					if !matches!(
-						self.peek(0).kind,
-						IDENTIFIER | CURLY_BRACKET_OPEN | ROUND_BRACKET_OPEN
-					) {
+					if match self.peek(0).kind {
+						IDENTIFIER | CURLY_BRACKET_OPEN | ROUND_BRACKET_OPEN => false,
+						_ => true,
+					} {
 						let t = self.peek(0);
 						return Err(self.expected("<table>", &t.lexeme, t.line));
 					}
@@ -579,7 +588,10 @@ impl ParserInfo {
 						let start = i.peek(0).line;
 						let expr = i.buildExpression(None)?;
 						let end = i.lookBack(1).line;
-						if matches!(i.lookBack(0).kind, CURLY_BRACKET_CLOSED | DEFAULT) {
+						if match i.lookBack(0).kind {
+							CURLY_BRACKET_CLOSED | DEFAULT => true,
+							_ => false,
+						} {
 							i.current -= 1
 						}
 						Ok(CodeBlock {
@@ -711,7 +723,7 @@ impl ParserInfo {
 				_ => break t,
 			}
 		};
-		if expr.is_empty() {
+		if expr.len() == 0 {
 			return Err(self.expected("<expr>", &last.lexeme, last.line));
 		}
 		self.assertEnd(&self.lookBack(0), end, expr)
@@ -1205,7 +1217,7 @@ pub fn ParseTokens(tokens: Vec<Token>, filename: String) -> Result<Expression, S
 				} {}
 				i.current -= 1;
 				let checkt = i.lookBack(0);
-				let check = checkt.kind as u8;
+				let check = checkt.kind.clone() as u8;
 				if check < DEFINE as u8 || check > MODULATE as u8 {
 					return Err(i.expected("=", &checkt.lexeme, checkt.line));
 				}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2,8 +2,7 @@
 
 use self::TokenType::*;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[rustfmt::skip]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TokenType {
 	//symbols
 	ROUND_BRACKET_OPEN, ROUND_BRACKET_CLOSED, SQUARE_BRACKET_OPEN,
@@ -39,7 +38,11 @@ pub struct Token {
 
 impl Token {
 	pub fn new(kind: TokenType, lexeme: String, line: usize) -> Token {
-		Token { kind, lexeme, line }
+		Token {
+			kind: kind,
+			lexeme: String::from(lexeme),
+			line: line,
+		}
 	}
 }
 
@@ -93,7 +96,7 @@ impl CodeInfo {
 		if self.at(self.current) != expected {
 			return false;
 		}
-		self.current += 1;
+		self.current = self.current + 1;
 		true
 	}
 
@@ -151,9 +154,7 @@ impl CodeInfo {
 	fn warning(&mut self, message: impl Into<String>) {
 		println!(
 			"Error in file \"{}\" at line {}!\nError: \"{}\"\n",
-			self.filename,
-			self.line,
-			message.into()
+			self.filename, self.line, message.into()
 		);
 		self.errored = true;
 	}
@@ -214,17 +215,17 @@ impl CodeInfo {
 		} else {
 			self.current += 1;
 			let mut literal: String = self.substr(self.start + 1, self.current - 1);
-			literal.retain(|c| !matches!(c, '\r' | '\n' | '\t'));
+			literal.retain(|c| match c {
+				'\r' | '\n' | '\t' => false,
+				_ => true,
+			});
 			self.addLiteralToken(STRING, literal);
 		}
 		self.line = aline;
 	}
 
 	fn reserved(&mut self, keyword: &str, msg: &str) -> TokenType {
-		self.warning(format!(
-			"'{}' is a reserved keyword in Lua and it cannot be used as a variable, {}",
-			keyword, msg
-		));
+		self.warning(format!("'{}' is a reserved keyword in Lua and it cannot be used as a variable, {}", keyword, msg));
 		IDENTIFIER
 	}
 }
@@ -272,7 +273,7 @@ pub fn ScanCode(code: String, filename: String) -> Result<Vec<Token>, String> {
 					}
 				}
 				'*' => {
-					while !(i.ended() || i.peek(0) == '*' && i.peek(1) == '/') {
+					while !i.ended() && !(i.peek(0) == '*' && i.peek(1) == '/') {
 						if i.peek(0) == '\n' {
 							i.line += 1
 						}
@@ -337,7 +338,8 @@ pub fn ScanCode(code: String, filename: String) -> Result<Vec<Token>, String> {
 									|c| {
 										let c = *c;
 										c.is_ascii_digit()
-											|| ('a'..='f').contains(&c) || ('A'..='F').contains(&c)
+											|| (c >= 'a' && c <= 'f')
+											|| (c >= 'A' && c <= 'F')
 									},
 									false,
 								);


### PR DESCRIPTION
Reverts 20886a1599dc6ab547b94cc0e1aca92ca1209801

# Problem

On this a commit a problem appeared in the parser. This example wouldn't compile.

# Reproduction

```
local t = {
    a = 3,
    meta index = {1+1}
}
```
