### PR TITLE
Add multiline strings

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -152,11 +152,15 @@ fn CompileExpression(mut scope: usize, names: Option<&Vec<String>>, expr: Expres
 				let expr = CompileExpression(scope, Some(&args), expr);
 				format!("({})", expr)
 			}
-			SYMBOL(lexeme) => lexeme,
-			MULTILINE_SYMBOL(lexeme) => {
-				let text = &lexeme[1..lexeme.len() - 1];
-				format!("[[{}]]", text)
+			SYMBOL(lexeme) => {
+				let chars: Vec<_> = lexeme.chars().collect();
+				if chars[0] == '`' && chars[lexeme.len() - 1] == '`' {
+					let text = &lexeme[1..lexeme.len() - 1];
+					return format!("[[{}]]", text);
+				}
+				lexeme
 			}
+
 			PSEUDO(num) => match names {
 				Some(names) => names
 					.get(num - 1)
@@ -267,10 +271,13 @@ pub fn CompileTokens(scope: usize, ctokens: Expression) -> String {
 	let ctokens = &mut ctokens.into_iter().peekable();
 	while let Some(t) = ctokens.next() {
 		result += &match t {
-			SYMBOL(lexeme) => lexeme,
-			MULTILINE_SYMBOL(lexeme) => {
-				let text = &lexeme[1..lexeme.len() - 1];
-				format!("[[{}]]", text)
+			SYMBOL(lexeme) => {
+				let chars: Vec<_> = lexeme.chars().collect();
+				if chars[0] == '`' && chars[lexeme.len() - 1] == '`' {
+					let text = &lexeme[1..lexeme.len() - 1];
+					return format!("[[{}]]", text);
+				}
+				lexeme
 			}
 			VARIABLE {
 				local,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -115,7 +115,6 @@ pub enum ComplexToken {
 	},
 
 	SYMBOL(String),
-	MULTILINE_SYMBOL(String),
 	PSEUDO(usize),
 	CALL(Vec<Expression>),
 	EXPR(Expression),
@@ -731,7 +730,7 @@ impl ParserInfo {
 					}
 				}
 				MULTILINE_STRING => {
-					expr.push_back(MULTILINE_SYMBOL(format!("`{}`", t.lexeme)));
+					expr.push_back(SYMBOL(format!("`{}`", t.lexeme)));
 					if self.checkVal() {
 						break t;
 					}


### PR DESCRIPTION
This PR adds multiline stings to clue. Although regular strings can span multiple lines any tab or newline characters are not preserved. This other type of multiline strings preserves those.

The \` symbol is used to denote multiline strings

```
print(`
hello
world
`)
```

When this program is run it should output

```
hello
world
```