### PR TITLE
Fixed some clippy warnings + auto-formatted the code

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold = 10
+too-many-arguments-threshold = 12

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -2,10 +2,10 @@ use std::fmt::Write;
 use std::iter::{Iterator, Peekable};
 
 use crate::{
+	env::ContinueMode,
 	flag,
 	parser::{CodeBlock, ComplexToken, ComplexToken::*, Expression, FunctionArgs},
 	scanner::TokenType::*,
-	env::ContinueMode,
 	ENV_DATA,
 };
 
@@ -226,11 +226,11 @@ fn compile_expression(mut scope: usize, names: Option<&Vec<String>>, expr: Expre
 					)
 				}
 			}
-			LAMBDA {args, code} => {
+			LAMBDA { args, code } => {
 				let (code, args) = compile_function(scope, names, args, code);
 				format!("function({}){}end", args, code)
 			}
-			IDENT {expr, ..} => compile_identifier(scope, names, expr),
+			IDENT { expr, .. } => compile_identifier(scope, names, expr),
 			CALL(args) => format!("({})", compile_expressions(scope, names, args)),
 			EXPR(expr) => format!("({})", compile_expression(scope, names, expr)),
 			_ => {
@@ -396,7 +396,7 @@ pub fn compile_tokens(scope: usize, ctokens: Expression) -> String {
 					let mut branches = branches.into_iter().peekable();
 					while let Some((conditions, extraif, code)) = branches.next() {
 						let empty = conditions.is_empty();
-						let default = empty && extraif == None;
+						let default = empty && extraif.is_none();
 						let pre = if default { "else" } else { "if" };
 						let condition = {
 							let mut condition = compile_list(conditions, "or ", &mut |expr| {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,21 +1,21 @@
-use std::fmt::Write;
 use clap::ArgEnum;
+use std::fmt::Write;
 
-#[derive(Copy, Clone, PartialEq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
 pub enum ContinueMode {
 	SIMPLE,
 	LUAJIT,
-	MOONSCRIPT
+	MOONSCRIPT,
 }
 
-#[derive(Copy, Clone, PartialEq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
 pub enum TypesMode {
 	NONE,
 	WARN,
-	STRICT
+	STRICT,
 }
 
-#[derive(Copy, Clone, PartialEq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
 pub enum LuaSTD {
 	NONE,
 	LUAJIT,
@@ -90,7 +90,7 @@ impl EnvData {
 		self.env_types = env_types;
 		self.env_std = env_std;
 	}
-	
+
 	pub fn env_tokens(&self) -> bool {
 		self.env_tokens
 	}
@@ -114,7 +114,7 @@ impl EnvData {
 	pub fn env_dontsave(&self) -> bool {
 		self.env_dontsave
 	}
-	
+
 	pub fn env_pathiscode(&self) -> bool {
 		self.env_pathiscode
 	}
@@ -130,7 +130,7 @@ impl EnvData {
 	pub fn env_types(&self) -> TypesMode {
 		self.env_types
 	}
-	
+
 	pub fn env_std(&self) -> LuaSTD {
 		self.env_std
 	}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,11 +1,14 @@
 #![allow(non_camel_case_types)]
 
 use self::ComplexToken::*;
+use crate::env::ContinueMode;
 use crate::scanner::TokenType::*;
 use crate::scanner::TokenType::{COMMA, CURLY_BRACKET_CLOSED, DEFINE, ROUND_BRACKET_CLOSED};
 use crate::{check, compiler::compile_tokens, flag, scanner::Token, scanner::TokenType, ENV_DATA};
-use crate::env::{ContinueMode/*, TypesMode*/};
-use std::{cmp, collections::{LinkedList, HashMap}};
+use std::{
+	cmp,
+	collections::{HashMap, LinkedList},
+};
 
 macro_rules! expression {
 	($($x: expr),*) => {
@@ -128,18 +131,16 @@ pub struct CodeBlock {
 }
 
 struct BorrowedToken {
-	token: *const Token
+	token: *const Token,
 }
 
 impl BorrowedToken {
 	fn new(token: *const Token) -> BorrowedToken {
-		BorrowedToken {token}
+		BorrowedToken { token }
 	}
 
 	fn token(&self) -> &Token {
-		unsafe {
-			&(*self.token)
-		}
+		unsafe { &(*self.token) }
 	}
 
 	fn kind(&self) -> TokenType {
@@ -159,9 +160,11 @@ impl BorrowedToken {
 	}
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LuaType {
-	ANY, NIL, NUMBER,
+	ANY,
+	NIL,
+	NUMBER,
 }
 
 struct ParserInfo {
@@ -174,7 +177,7 @@ struct ParserInfo {
 	localid: u8,
 	statics: String,
 	macros: HashMap<String, Expression>,
-	locals: LocalsList
+	locals: LocalsList,
 }
 
 impl ParserInfo {
@@ -189,7 +192,7 @@ impl ParserInfo {
 			localid: 0,
 			statics: String::new(),
 			macros: HashMap::new(),
-			locals
+			locals,
 		}
 	}
 
@@ -207,7 +210,12 @@ impl ParserInfo {
 	}
 
 	fn warning(&self, msg: impl Into<String>, line: usize) {
-		println!("Warning in file \"{}\" at line {}!\nWarning: \"{}\"", self.filename, line, msg.into());
+		println!(
+			"Warning in file \"{}\" at line {}!\nWarning: \"{}\"",
+			self.filename,
+			line,
+			msg.into()
+		);
 	}
 
 	fn error(&mut self, msg: impl Into<String>, line: usize) -> String {
@@ -275,7 +283,11 @@ impl ParserInfo {
 		true
 	}
 
-	fn assert_advance(&mut self, expected: TokenType, error: &str) -> Result<BorrowedToken, String> {
+	fn assert_advance(
+		&mut self,
+		expected: TokenType,
+		error: &str,
+	) -> Result<BorrowedToken, String> {
 		let t = self.advance();
 		if t.kind() != expected {
 			return Err(self.expected(error, &t.lexeme(), t.line()));
@@ -291,7 +303,12 @@ impl ParserInfo {
 		Ok(())
 	}
 
-	fn assert_end<T>(&mut self, tocheck: &BorrowedToken, end: OptionalEnd, iftrue: T) -> Result<T, String> {
+	fn assert_end<T>(
+		&mut self,
+		tocheck: &BorrowedToken,
+		end: OptionalEnd,
+		iftrue: T,
+	) -> Result<T, String> {
 		if let Some((kind, lexeme)) = end {
 			if tocheck.kind() != kind {
 				return Err(self.expected(lexeme, &tocheck.lexeme(), tocheck.line()));
@@ -524,7 +541,7 @@ impl ParserInfo {
 		t: &BorrowedToken,
 		expr: &mut Expression,
 		fname: impl Into<String>,
-		end: OptionalEnd
+		end: OptionalEnd,
 	) -> Result<(), String> {
 		self.check_operator(t, true)?;
 		let mut arg1 = Expression::new();
@@ -572,8 +589,8 @@ impl ParserInfo {
 
 	fn check_val(&mut self) -> bool {
 		match self.peek(0).kind() {
-			NUMBER | IDENTIFIER | STRING | DOLLAR | PROTECTED_GET | TRUE | BIT_NOT
-			| FALSE | NIL | NOT | HASHTAG | CURLY_BRACKET_OPEN | THREEDOTS | MATCH => {
+			NUMBER | IDENTIFIER | STRING | DOLLAR | PROTECTED_GET | TRUE | BIT_NOT | FALSE
+			| NIL | NOT | HASHTAG | CURLY_BRACKET_OPEN | THREEDOTS | MATCH => {
 				self.current += 1;
 				true
 			}
@@ -815,7 +832,7 @@ impl ParserInfo {
 						(FunctionArgs::new(), None)
 					};
 					let code = self.build_function_block(types)?;
-					expr.push_back(LAMBDA {args, code});
+					expr.push_back(LAMBDA { args, code });
 					if self.check_val() {
 						break t;
 					}
@@ -922,7 +939,7 @@ impl ParserInfo {
 				_ => break,
 			}
 		}
-		Ok(IDENT {expr, line})
+		Ok(IDENT { expr, line })
 	}
 
 	fn get_code_block_start(&mut self) -> Result<usize, String> {
@@ -935,7 +952,11 @@ impl ParserInfo {
 		}
 	}
 
-	fn parse_code_block(&self, mut tokens: Vec<Token>, locals: LocalsList) -> Result<Expression, String> {
+	fn parse_code_block(
+		&self,
+		mut tokens: Vec<Token>,
+		locals: LocalsList,
+	) -> Result<Expression, String> {
 		if tokens.is_empty() {
 			Ok(Expression::new())
 		} else {
@@ -969,7 +990,10 @@ impl ParserInfo {
 		Ok(CodeBlock { start, code, end })
 	}
 
-	fn build_function_block(&mut self, args: Option<Vec<(String, LuaType)>>) -> Result<CodeBlock, String> {
+	fn build_function_block(
+		&mut self,
+		args: Option<Vec<(String, LuaType)>>,
+	) -> Result<CodeBlock, String> {
 		if let Some(args) = args {
 			self.build_code_block({
 				let mut locals = self.locals.clone().unwrap();
@@ -1071,9 +1095,11 @@ impl ParserInfo {
 		Ok(idents)
 	}
 
-	fn build_function_args(&mut self) -> Result<(FunctionArgs, Option<Vec<(String, LuaType)>>), String> {
+	fn build_function_args(
+		&mut self,
+	) -> Result<(FunctionArgs, Option<Vec<(String, LuaType)>>), String> {
 		let mut args = FunctionArgs::new();
-		let mut types: Option<Vec<(String, LuaType)>> = if self.locals != None {
+		let mut types: Option<Vec<(String, LuaType)>> = if self.locals.is_some() {
 			Some(Vec::new())
 		} else {
 			None
@@ -1091,11 +1117,14 @@ impl ParserInfo {
 				}
 			};
 			if let Some(types) = &mut types {
-				types.push((name.lexeme(), if name.kind() == THREEDOTS {
-					LuaType::ANY
-				} else {
-					self.build_type()?
-				}))
+				types.push((
+					name.lexeme(),
+					if name.kind() == THREEDOTS {
+						LuaType::ANY
+					} else {
+						self.build_type()?
+					},
+				))
 			}
 			let t = self.advance();
 			match t.kind() {
@@ -1139,7 +1168,9 @@ impl ParserInfo {
 				let t = self.advance();
 				match t.kind() {
 					ELSEIF => Some(Box::new(self.build_elseif_chain()?)),
-					ELSE => Some(Box::new(DO_BLOCK(self.build_code_block(self.locals.clone())?))),
+					ELSE => Some(Box::new(DO_BLOCK(
+						self.build_code_block(self.locals.clone())?,
+					))),
 					_ => {
 						self.current -= 1;
 						None
@@ -1190,7 +1221,7 @@ impl ParserInfo {
 		}
 		if let Some(locals) = &mut self.locals {
 			for r#enum in &enums {
-				if let VARIABLE {names, ..} = r#enum {
+				if let VARIABLE { names, .. } = r#enum {
 					locals.insert(names[0].clone(), LuaType::NUMBER);
 				}
 			}
@@ -1209,7 +1240,7 @@ impl ParserInfo {
 			(FunctionArgs::new(), None)
 		};
 		let code = self.build_function_block(types)?;
-		if self.locals != None {
+		if self.locals.is_some() {
 			self.add_variable(t.lexeme(), LuaType::NIL);
 		}
 		Ok(FUNCTION {
@@ -1236,7 +1267,7 @@ impl ParserInfo {
 
 	fn build_variable(&mut self) -> Result<(String, LuaType), String> {
 		let name = self.assert_advance(IDENTIFIER, "<name>")?.lexeme();
-		if self.locals != None {
+		if self.locals.is_some() {
 			let luatype = self.build_type()?;
 			self.add_variable(name.to_string(), luatype.clone());
 			Ok((name, luatype))
@@ -1268,7 +1299,7 @@ impl ParserInfo {
 					self.warning("Defining external globals will not do anything if you don't have type checking enabled!", line)
 				}
 				self.current -= 1;
-				return Ok(SYMBOL(String::new()))
+				return Ok(SYMBOL(String::new()));
 			}
 		} else {
 			self.find_expressions(COMMA, None)?
@@ -1343,7 +1374,11 @@ impl ParserInfo {
 					}
 					IF => {
 						let extraif = self.build_expression(Some((ARROW, "=>")))?;
-						branches.push((Vec::new(), Some(extraif), func(self, self.locals.clone())?));
+						branches.push((
+							Vec::new(),
+							Some(extraif),
+							func(self, self.locals.clone())?,
+						));
 						!self.advance_if(CURLY_BRACKET_CLOSED)
 					}
 					_ => return Err(self.expected("=>", &t.lexeme(), t.line())),
@@ -1464,7 +1499,7 @@ impl ParserInfo {
 					let expr = &mut self.build_expression(None)?;
 					self.expr.append(expr);
 					self.current -= 1;
-					return Ok(())
+					return Ok(());
 				}
 				_ => return Err(self.error(msg, self.testing.unwrap())),
 			}
@@ -1689,7 +1724,11 @@ impl ParserInfo {
 	}
 }
 
-pub fn parse_tokens(tokens: Vec<Token>, locals: Option<HashMap<String, LuaType>>, filename: String) -> Result<Expression, String> {
+pub fn parse_tokens(
+	tokens: Vec<Token>,
+	locals: Option<HashMap<String, LuaType>>,
+	filename: String,
+) -> Result<Expression, String> {
 	let mut i = ParserInfo::new(tokens, locals, filename);
 	while !i.ended() {
 		let t = i.advance();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -40,7 +40,11 @@ pub struct Token {
 
 impl Token {
 	pub fn new(kind: TokenType, lexeme: impl Into<String>, line: usize) -> Token {
-		Token {kind, lexeme: lexeme.into(), line}
+		Token {
+			kind,
+			lexeme: lexeme.into(),
+			line,
+		}
 	}
 }
 
@@ -240,12 +244,20 @@ impl CodeInfo {
 			self.current += 1;
 			let literal: String = self.substr(self.start + 1, self.current - 1);
 			let mut brackets = String::new();
-			let mut must = literal.ends_with("]");
+			let mut must = literal.ends_with(']');
 			while must || literal.contains(&format!("]{}]", brackets)) {
 				brackets += "=";
 				must = false;
 			}
-			self.add_literal_token(STRING, format!("[{}[{}]{}]", brackets, literal.replace("\\`", "`"), brackets));
+			self.add_literal_token(
+				STRING,
+				format!(
+					"[{}[{}]{}]",
+					brackets,
+					literal.replace("\\`", "`"),
+					brackets
+				),
+			);
 		}
 		self.line = aline
 	}
@@ -324,7 +336,7 @@ pub fn scan_code(code: String, filename: String) -> Result<Vec<Token>, String> {
 						i.current += 2;
 					}
 				}
-				_ => i.match_and_add('=', DIVIDE, '_', FLOOR_DIVISION, SLASH)
+				_ => i.match_and_add('=', DIVIDE, '_', FLOOR_DIVISION, SLASH),
 			},
 			'%' => i.compare_and_add('=', MODULATE, PERCENTUAL),
 			'!' => i.compare_and_add('=', NOT_EQUAL, NOT),
@@ -418,10 +430,7 @@ pub fn scan_code(code: String, filename: String) -> Result<Vec<Token>, String> {
 						"false" => FALSE,
 						"nil" => NIL,
 						"break" => BREAK,
-						_ if match i.last {
-							DOT | SAFEDOT | DOUBLE_COLON | SAFE_DOUBLE_COLON => true,
-							_ => false
-						} => IDENTIFIER,
+						_ if matches!(i.last, DOT | SAFEDOT | DOUBLE_COLON | SAFE_DOUBLE_COLON) => IDENTIFIER,
 						"of" => OF,
 						"with" => WITH,
 						"meta" => META,


### PR DESCRIPTION
As per title.
Also, there are two warnings from Clippy that should be addressed (they're about readability) by either fixing them or ignoring them
```
warning: methods called `into_*` usually take `self` by value
   --> src/parser.rs:158:16
    |
158 |     fn into_owned(&self) -> Token {
    |                   ^^^^^
    |
    = note: `#[warn(clippy::wrong_self_convention)]` on by default
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```

```
warning: very complex type used. Consider factoring parts into `type` definitions
    --> src/parser.rs:1100:7
     |
1100 |     ) -> Result<(FunctionArgs, Option<Vec<(String, LuaType)>>), String> {
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(clippy::type_complexity)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
```