### PR TITLE
Fixed some clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -249,12 +249,12 @@ fn main() -> Result<(), String> {
 					};
 					check!(std::str::from_utf8(&base))
 						.to_string()
-						.replace("--STATICS\n", &statics)
-						.replace("§", &output)
+						.replace("--STATICS\n", statics)
+						.replace('§', output)
 				}
 				None => include_str!("base.lua")
-					.replace("--STATICS\n", &statics)
-					.replace("§", &output),
+					.replace("--STATICS\n", statics)
+					.replace('§', output),
 			});
 		if !cli.dontsave {
 			let outputname = &format!(


### PR DESCRIPTION
As per title
`main.rs`: Replaced `"` with `'` for single character strings
`main.rs`: Replaced `&statistics` with `statistics`
`main.rs`: Replaced `&output` with `output`
`parser.rs`: Replaced a super-duper-complex-long type with a simpler one (the name of it is temporary)
`parser.rs`: Changed `into_owned` to take the value and not to borrow + changed `clone` to `to_owned`
`parser.rs`: Added a TODO in the `assert_variable` function

All the remaining warnings from clippy are related to the `assert_variable` function