### PR TITLE
Bumped clap version and Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clue"
 version = "2.5.0"
 description = "C/Rust like programming language that compiles into Lua code"
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 authors = ["Maiori"]
 repository = "https://github.com/ClueLang/Clue"
@@ -14,5 +14,5 @@ categories = ["compilers"]
 winres = "0.1"
 
 [dependencies]
-clap = {version = "3.1.6", features = ["derive"]}
+clap = {version = "4.0.18", features = ["derive"]}
 lazy_static = "1.4.0"

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,21 +1,21 @@
-use clap::ArgEnum;
+use clap::ValueEnum;
 use std::fmt::Write;
 
-#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum ContinueMode {
 	SIMPLE,
 	LUAJIT,
 	MOONSCRIPT,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum TypesMode {
 	NONE,
 	WARN,
 	STRICT,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, ArgEnum)]
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum LuaSTD {
 	NONE,
 	LUAJIT,


### PR DESCRIPTION
In order to bump the clap version it was required to make some changes in env.rs, namely renaming ArgEnum to ValueEnum