### PR TITLE
fix string lexer when string end with '\\'

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -207,9 +207,18 @@ impl CodeInfo {
 		self.addToken(NUMBER);
 	}
 
+	fn skipEscape(&mut self) {
+		self.current += 1;
+	}
+
 	fn readString(&mut self, strend: char) {
 		let mut aline = self.line;
-		while !self.ended() && (self.peek(0) != strend || self.lookBack(0) == '\\') {
+		while !self.ended() && self.peek(0) != strend {
+
+			if self.peek(0) == '\\'{
+				self.skipEscape();
+			}
+			
 			if self.peek(0) == '\n' {
 				aline += 1
 			};


### PR DESCRIPTION
test case:
```
local a = 'c:\\11\\22\\33\\44\\'
```

clue v2.5.0 will run with error
```
Error in file "test.clue" at line 2!
Error: "Unterminated string"

Error: "Cannot continue until the above errors are fixed"
```