### PR TITLE
Slight increase in runtime performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ winres = "0.1"
 clap = {version = "3.2.23", features = ["derive"]}
 lazy_static = "1.4.0"
 hashbrown = "0.13.1"
+num_cpus = "1.14.0"
 devtimer = { version = "4.0.1", optional = true }
 rpmalloc = { version = "0.2.2", optional = true }
 mlua = {version = "0.8.3", features = ["luajit", "vendored"], optional = true}

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,10 +180,7 @@ where
 	P: AsRef<OsStr> + Display,
 {
 	let files = Arc::new(Mutex::new(check_for_files(path)?));
-	let threads_count = min(
-		std::thread::available_parallelism()?.get(),
-		files.lock().unwrap().len(),
-	);
+	let threads_count = min(files.lock().unwrap().len(), num_cpus::get() * 2);
 	let mut threads = Vec::with_capacity(threads_count);
 
 	for _ in 0..threads_count {
@@ -358,13 +355,8 @@ fn main() -> Result<(), String> {
 
 #[cfg(feature = "devtimer")]
 fn compile_multi_files_bench(files: Vec<String>) {
+	let threads_count = min(files.len(), num_cpus::get() * 2);
 	let files = Arc::new(Mutex::new(files));
-	let threads_count = min(
-		std::thread::available_parallelism()
-			.expect("Unexpected error happened when checking for how many parallelism is available")
-			.get(),
-		files.lock().unwrap().len(),
-	);
 	let mut threads = Vec::with_capacity(threads_count);
 
 	for _ in 0..threads_count {


### PR DESCRIPTION
By using the crate `num_cpus` it was possible to get the number of available cores faster than `available_parallelism` so the compiler is faster at startup to split the work among all the cores
To add to that, I doubled the work on the cores for a slightly increase in performance