### PR TITLE
Add testing for wasm and drop 32 bit builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,6 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             host_cc: ""
             target_cc: ""
-          - target: i686-unknown-linux-gnu
-            host_cc: i686-linux-gnu
-            target_cc: i686-linux-gnu
           - target: aarch64-unknown-linux-gnu
             host_cc: ""
             target_cc: aarch64-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,20 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          default: true
-          override: true
-          toolchain: nightly
-          target: "i686-pc-windows-msvc"
       - name: Cache build
         uses: Swatinem/rust-cache@v2
-      - name: Test dev build
+      - name: Test core
         run: cargo test
-      - name: Test release build
-        run: cargo test --release
+  test-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Cache build
+        uses: Swatinem/rust-cache@v2
+      - name: Setup
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack
+      - name: Test wasm
+        run: wasm-pack test --node

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ flume = "0.10.14"
 num_cpus = "1.14.0"
 crossbeam-queue = "0.3.8"
 ahash.workspace = true
-clue_core = { path = "../core", version = "3.3.0-indev+20c76c02", default-features = false }
+clue_core = { path = "../core", version = "3.3.0-indev", default-features = false }
 clap.workspace = true
 mlua = { version = "0.8.3", features = ["luajit", "vendored"], optional = true }
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -17,8 +17,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde = "1.0.159"
 wasm-bindgen = "0.2.84"
-clue_core = { path = "../core", version = "3.3.0-indev+20c76c02", default-features = false, features = [
+clue_core = { path = "../core", version = "3.3.0-indev", default-features = false, features = [
     "serde",
 ] }
 serde-wasm-bindgen = "0.5.0"
 getrandom = { version = "0.2.3", features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -262,3 +262,21 @@ impl Default for Clue {
 		Self::new()
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use wasm_bindgen_test::*;
+
+	#[wasm_bindgen_test]
+	fn test_version() {
+		assert_eq!(get_version(), env!("CARGO_PKG_VERSION"));
+	}
+
+	#[wasm_bindgen_test]
+	fn test_compiles() {
+		let clue = Clue::new();
+		clue.compile_code(include_str!("../../examples/fizzbuzz.clue").to_owned())
+			.unwrap();
+	}
+}


### PR DESCRIPTION
This PR adds testing for wasm and drops 32 bit builds.

Closes #105, with removing 32 bit builds