### PR TITLE
Fix release tarball compression

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Bench

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           TARGET_CFLAGS: "--target=${{ matrix.target }}"
         run: |
           cargo build --release --target=${{ matrix.target }} -vv
-          cd target/${{ matrix.target }}/release/ && tar -cvf "$CRATE_NAME-${{ matrix.target }}.tar.gz" "$CRATE_NAME" && cd ../../..
+          ( cd target/${{ matrix.target }}/release/ && tar -cavf "$CRATE_NAME-${{ matrix.target }}.tar.gz" "$CRATE_NAME" )
       - name: Upload clue-${{ matrix.target }}.tar.gz
         uses: actions/upload-artifact@v3
         with:
@@ -119,7 +119,7 @@ jobs:
       - name: Build ${{ matrix.target }}
         run: |
           cargo build --target=${{ matrix.target }} --release -vv
-          cd target/${{ matrix.target }}/release/ && tar -cvf "$CRATE_NAME-${{ matrix.target }}.tar.gz" "$CRATE_NAME" && cd ../../..
+          ( cd target/${{ matrix.target }}/release/ && tar -cavf "$CRATE_NAME-${{ matrix.target }}.tar.gz" "$CRATE_NAME" )
       - name: Build deb
         run: |
           cd cli && cargo deb -p clue --target=${{ matrix.target }} && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       CRATE_NAME: "clue"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Build ${{ matrix.target }}
@@ -21,7 +21,7 @@ jobs:
           cargo build  --target=${{ matrix.target }} --release -vv
           cd target\${{ matrix.target }}\release && tar -cavf "$env:CRATE_NAME-${{ matrix.target }}.zip" "$env:CRATE_NAME.exe"  && cd ../../..
       - name: Upload clue-${{ matrix.target }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CRATE_NAME }}-${{ matrix.target }}.zip
           path: target\${{ matrix.target }}\release\${{ env.CRATE_NAME }}-${{ matrix.target }}.zip
@@ -42,7 +42,7 @@ jobs:
       CRATE_NAME: "clue"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Setup
@@ -55,7 +55,7 @@ jobs:
           cargo build --release --target=${{ matrix.target }} -vv
           ( cd target/${{ matrix.target }}/release/ && tar -cavf "$CRATE_NAME-${{ matrix.target }}.tar.gz" "$CRATE_NAME" )
       - name: Upload clue-${{ matrix.target }}.tar.gz
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CRATE_NAME }}-${{ matrix.target }}.tar.gz
           path: target/${{ matrix.target }}/release/${{ env.CRATE_NAME }}-${{ matrix.target }}.tar.gz
@@ -87,7 +87,7 @@ jobs:
       CRATE_NAME: "clue"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Setup
@@ -129,17 +129,17 @@ jobs:
           cargo-make-rpm -p clue --target=${{ matrix.target }}
           echo "RPM_FILENAME=$(basename $(echo target/${{ matrix.target }}/rpm/*.rpm))" >> $GITHUB_ENV
       - name: Upload ${{ env.CRATE_NAME }}-${{ matrix.target }}.tar.gz
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CRATE_NAME }}-${{ matrix.target }}.tar.gz
           path: target/${{ matrix.target }}/release/*.tar.gz
       - name: Upload ${{ env.DEB_FILENAME }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.DEB_FILENAME }}
           path: target/${{ matrix.target }}/debian/*.deb
       - name: Upload ${{ env.RPM_FILENAME }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RPM_FILENAME }}
           path: target/${{ matrix.target }}/rpm/*.rpm
@@ -157,7 +157,7 @@ jobs:
       CRATE_NAME: "clue"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Setup
@@ -170,7 +170,7 @@ jobs:
           wasm-pack build --target web --release
           zip -r clue_wasm.zip pkg
       - name: Upload clue_wasm.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: clue_wasm.zip
           path: wasm/clue_wasm.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Publish core
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Setup
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache build
         uses: Swatinem/rust-cache@v2
       - name: Setup

--- a/core/src/scanner.rs
+++ b/core/src/scanner.rs
@@ -564,9 +564,7 @@ const SYMBOLS: SymbolsMap = generate_map(&[
 	(
 		':',
 		SymbolType::Symbols(
-			generate_map(&[
-				(':', SymbolType::Just(DOUBLE_COLON)),
-			]),
+			generate_map(&[(':', SymbolType::Just(DOUBLE_COLON))]),
 			COLON,
 		),
 	),


### PR DESCRIPTION
The release tarballs are not actually gzip compressed. This has pretty much been a bug in the workflow since forever.